### PR TITLE
fix: remove geopy and add pyshp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python >=3.6
     - setuptools_scm
   run:
-    - geopy >=1.18.1
+    - pyshp >=2.1
     - matplotlib-base >=2.2.2
     - networkx >=2.0.0
     - numpy >=1.14.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tropycal" %}
-{% set version = "0.4.2" %}
+{% set version = "0.5" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/tropycal-{{ version }}.tar.gz
-  sha256: 89f15a2a5a9cefec0dd07e6e30016f0733ec070468821730c4b03122c91addea
+  sha256: af059141ab2a45d41852ebfe80ae44ea88e399405c88e4b53bb84173d279a04b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - raybellwaves
+    - tomerburg


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The meta.yaml file listed here is outdated. This fix removes a dependence on "geopy" that no longer exists, and adds a new dependence "pyshp", which appears to have caused v0.5 to fail updating on conda-forge after successfully updating on pip.