### PR TITLE
tropycal v1.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tropycal" %}
-{% set version = "1.5" %}
+{% set version = "1.5.1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/tropycal-{{ version }}.tar.gz
-  sha256: a16660422ea02fa363260a790ef62358c02ca41f28e7a1684464df3b93f42f8c
+  sha256: 86e289458ed34cbf019ce69b935c5c31420c8a464329a4383357ec5ea08f5d7f
 
 build:
   number: 0


### PR DESCRIPTION
Update tropycal to v1.5.1 (bug fix release: IBTrACS v04r01 jtwc_neumann parsing).

- Version 1.5 -> 1.5.1, new sdist sha256
- Build number remains 0 (new version)
- No dependency changes

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for new version)
- [x] Re-rendered with the latest conda-smithy
- [x] Ensured the license file is being packaged